### PR TITLE
update to project name

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -14,7 +14,7 @@ paver.setuputils.install_distutils_tasks()
 sys.path.append(os.getcwd())
 
 # The project name, for use below.
-project_name = 'COMP1000UofM'
+project_name = 'FOPP-PIE'
 
 master_url = 'http://127.0.0.1:8000'
 if not master_url:

--- a/sphinx_settings.json
+++ b/sphinx_settings.json
@@ -1,1 +1,1 @@
-{"SPHINX_SOURCE_PATH": "_sources", "SPHINX_OUT_PATH": "build/COMP1000UofM"}
+{"SPHINX_SOURCE_PATH": "_sources", "SPHINX_OUT_PATH": "build/FOPP-PIE"}


### PR DESCRIPTION
Changed project name to FOPP-PIE in pavement.py
Note that now when you do a Runestone build --all the local file directory will have changed: build/FOPP-PIE