### PR TITLE
Update ExploringTurtleModule.rst

### DIFF
--- a/_sources/DebuggingAndModules/ExploringTurtleModule.rst
+++ b/_sources/DebuggingAndModules/ExploringTurtleModule.rst
@@ -178,16 +178,16 @@ screen until we click on it.
    True or False: A Turtle object can have any name that follows the naming rules from Chapter 2.
 
 .. mchoice:: question3_11_5
-   :answer_a: <img src="../_static/test1Alt1.png" alt="right turn of 90 degrees before drawing, draw a line 150 pixels long, turn left 90, and draw a line 75 pixels long">
-   :answer_b: <img src="../_static/test1Alt2.png" alt="left turn of 180 degrees before drawing,  draw a line 150 pixels long, turn left 90, and draw a line 75 pixels long">
-   :answer_c: <img src="../_static/test1Alt3.png" alt="left turn of 270 degrees before drawing,  draw a line 150 pixels long, turn left 90, and draw a line 75 pixels long">
-   :answer_d: <img src="../_static/test1Alt4v2.png" alt="right turn of 270 degrees before drawing, draw a line 150 pixels long, turn right 90, and draw a line 75 pixels long">
-   :answer_e: <img src="../_static/test1correct.png" alt="left turn of 90 degrees before drawing,  draw a line 150 pixels long, turn left 90, and draw a line 75 pixels long">
+   :answer_a: right turn of 90 degrees before drawing, draw a line 150 pixels long, turn left 90, and draw a line 75 pixels long
+   :answer_b: left turn of 180 degrees before drawing,  draw a line 150 pixels long, turn left 90, and draw a line 75 pixels long
+   :answer_c: left turn of 270 degrees before drawing,  draw a line 150 pixels long, turn left 90, and draw a line 75 pixels long
+   :answer_d: right turn of 270 degrees before drawing, draw a line 150 pixels long, turn right 90, and draw a line 75 pixels long
+   :answer_e: left turn of 90 degrees before drawing,  draw a line 150 pixels long, turn left 90, and draw a line 75 pixels long
    :correct: e
-   :feedback_a: This code would turn the turtle to the south before drawing
-   :feedback_b: This code would turn the turtle to the west before drawing
-   :feedback_c: This code would turn the turtle to the south before drawing
-   :feedback_d: This code is almost correct, but the short end would be facing east instead of west.
+   :feedback_a: This would turn the turtle to the south before drawing
+   :feedback_b: This would turn the turtle to the west before drawing
+   :feedback_c: This would turn the turtle to the south before drawing
+   :feedback_d: This is almost correct, but the short end would be facing east instead of west.
    :feedback_e: Yes, the turtle starts facing east, so to turn it north you can turn left 90 or right 270 degrees.
 
    Which of the following sequence of instructions would produce the following image?


### PR DESCRIPTION
Fixed error with missing images in Exercise 3.11.7 - just removed image references, since a description of the tasks is fine.