### PR TITLE
Fixed typo "immuatable" + fixed example code that contained an error

### DIFF
--- a/source/DataAndInstructions/Assessment.ptx
+++ b/source/DataAndInstructions/Assessment.ptx
@@ -315,10 +315,15 @@ def square(num):
 			<p>
 				:
 			</p>
-
-			<image source="DataAndInstructions/Figures/cdq2-5.png" width="50%"/>
+			<program language="python"><input>
+				name = "sara"
+				age = 11
+				info = name + " " + str(age)
+				print(info)
+				</input>
+			</program>
 				<p>
-					Here is that same image of code again.
+					Here is that same code again, but the error has been fixed.
 					Which line number shows a line of code we would define as an expression?
 				</p>
 			</statement>

--- a/source/Sequences/PassingMutableObjects.ptx
+++ b/source/Sequences/PassingMutableObjects.ptx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<section xml:id="sequences_passing-mutable-vs-immuatable-objects">
+<section xml:id="sequences_passing-mutable-vs-immutable-objects">
   <title>Passing Mutable vs Immuatable Objects</title>
   <subsection xml:id="sequences_local-editing">
     <title>Editing local values</title>


### PR DESCRIPTION
Fixed example code for question 2.18.9 except three of the assessment questions have been commented out so it's now checkpoint 2.18.6